### PR TITLE
Throw InvalidOperationException - Fixes issue #31

### DIFF
--- a/source/Xamvvm.Forms/Factory/FactoryCaching.cs
+++ b/source/Xamvvm.Forms/Factory/FactoryCaching.cs
@@ -54,8 +54,14 @@ namespace Xamvvm
 			{
 				page = pageCreationFunc() as IBasePage<TPageModel>;
 			}
-			else
+			else 
+			{ 
+				if(pageType == null) 
+				{
+					throw new InvalidOperationException($"No page associated with {typeof(TPageModel).Name}");
+				}
 				page = Activator.CreateInstance(pageType) as IBasePage<TPageModel>;
+			}
 
 			if (pageModel != null)
 			{
@@ -113,8 +119,14 @@ namespace Xamvvm
 			{
 				page = pageCreationFunc() as IBasePage<IBasePageModel>;
 			}
-			else
+			else 
+			{
+				if (pageType == null) 
+				{
+					throw new InvalidOperationException($"No page associated with {pageModelType.Name}");
+				}
 				page = Activator.CreateInstance(pageType) as IBasePage<IBasePageModel>;
+			}
 
 			Func<object> pageModelCreationFunc;
 			if (_pageModelCreation.TryGetValue(pageModelType, out pageModelCreationFunc))


### PR DESCRIPTION
In both the generic and non-generic version of GetPageAsNewInstance
added a check to see if the Page type is found, if not an
InvalidOperationException is thrown with the name of the PageModel.