### PR TITLE
Call Dispose on PageModel. Fixes #19

### DIFF
--- a/source/Xamvvm.Forms/Factory/FactoryCaching.cs
+++ b/source/Xamvvm.Forms/Factory/FactoryCaching.cs
@@ -136,6 +136,11 @@ namespace Xamvvm
 				var navEventsPage = page as INavigationRemovingFromCache;
 				if (navEventsPage != null)
 					navEventsPage.NavigationRemovingFromCache();
+
+				var pageModel = (page as IBasePage<TPageModel>)?.GetPageModel();
+				if(pageModel != null) {
+					(pageModel as IDisposable)?.Dispose();
+				}
 				
 				_pageCache.Remove(key);
 				_pageCacheHits.Remove(key);

--- a/source/Xamvvm.Forms/Factory/FactoryCaching.cs
+++ b/source/Xamvvm.Forms/Factory/FactoryCaching.cs
@@ -138,7 +138,8 @@ namespace Xamvvm
 					navEventsPage.NavigationRemovingFromCache();
 
 				var pageModel = (page as IBasePage<TPageModel>)?.GetPageModel();
-				if(pageModel != null) {
+				if(pageModel != null)
+				{
 					(pageModel as IDisposable)?.Dispose();
 				}
 				


### PR DESCRIPTION
If the PageModel is IDisposable, call Dispose when removing the PageModel from the cache.
